### PR TITLE
Fixes #3093. Use add instead of create.

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1542,7 +1542,7 @@ class TaskThread extends ObjectThread {
         $vars['message'] = $vars['description'];
         unset($vars['description']);
 
-        return MessageThreadEntry::create($vars, $errors);
+        return MessageThreadEntry::add($vars, $errors);
     }
 
     static function create($task=false) {

--- a/include/html2text.php
+++ b/include/html2text.php
@@ -1014,7 +1014,7 @@ function mb_wordwrap($string, $width=75, $break="\n", $cut=false) {
   } else {
     // Anchor the beginning of the pattern with a lookahead
     // to avoid crazy backtracking when words are longer than $width
-    $pattern = '/(?=[\s\p{Ps}])(.{1,'.$width.'})(?:\s|$|(\p{Ps}))/uS';
+    $search = '/(?=[\s\p{Ps}])(.{1,'.$width.'})(?:\s|$|(\p{Ps}))/uS';
     $replace = '$1'.$break.'$2';
   }
   return rtrim(preg_replace($search, $replace, $string), $break);


### PR DESCRIPTION
As described in https://github.com/osTicket/osTicket/issues/3093 after adding a task, the text I entered in the description field is missing.
This PR fixes that.
